### PR TITLE
fix: bump javascript-node image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // More info: https://containers.dev/implementors/json_reference/
 {
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:3-24-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Bump javascript-node image version in devcontainer.json to the updated release